### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Butterfly is a **lightweight** library for integrating bug-report and feedback f
 
 ## Goals of this project
 
-One of the main issues accross the iOS development is the feedback of new features and bug report.
+One of the main issues across the iOS development is the feedback of new features and bug report.
 
 The most common way is to use `mailto` to send a dry and boring email :
 


### PR DESCRIPTION
@wongzigii, I've corrected a typographical error in the documentation of the [Butterfly](https://github.com/wongzigii/Butterfly) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
